### PR TITLE
Kali linux link added in Where to Fish section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Where to fish?
 
 Plecost is available on:
 
+* Kali Linux http://www.kali.org/
 * BackTrack 5 http://www.backtrack-linux.org/
 * BackBox http://www.backbox.org/
 


### PR DESCRIPTION
I have tested it on Kali Linux. Perhaps you forget to add it in your list :P
