### PR TITLE
feat: Enhance XML-RPC module with active guardrail validation and amplification checks

### DIFF
--- a/plecost/locales/en.json
+++ b/plecost/locales/en.json
@@ -133,6 +133,21 @@
       "description": "system.listMethods is available, allowing attackers to enumerate all available XML-RPC methods.",
       "remediation": "Disable XML-RPC entirely if not needed."
     },
+    "pc_xmlrpc_004": {
+      "title": "XML-RPC system.multicall enabled (Brute-force amplification)",
+      "description": "The system.multicall method is enabled in XML-RPC, allowing attackers to bypass rate limits and perform massive brute-force attacks by sending thousands of credentials in a single request.",
+      "remediation": "Disable system.multicall or restrict XML-RPC access entirely."
+    },
+    "pc_xmlrpc_005": {
+      "title": "XML-RPC Brute-Force Protection Missing",
+      "description": "The xmlrpc.php endpoint is accessible and does not appear to enforce rate limiting on failed authentication attempts. It successfully processed consecutive failed logins.",
+      "remediation": "Implement rate limiting via a WAF, security plugin, or Fail2Ban, or disable XML-RPC entirely."
+    },
+    "pc_xmlrpc_info": {
+      "title": "XML-RPC Guardrails Active",
+      "description": "The xmlrpc.php endpoint is accessible, but active defenses (WAF/Rate Limiting) successfully blocked repeated authentication attempts.",
+      "remediation": "No immediate action required. Defenses are working as expected."
+    },
     "pc_rest_001": {
       "title": "REST API link exposed in HTML head",
       "description": "The WordPress REST API discovery link is present in the HTML head, confirming WordPress installation.",

--- a/plecost/locales/es.json
+++ b/plecost/locales/es.json
@@ -133,6 +133,21 @@
       "description": "system.listMethods está disponible, permitiendo a atacantes enumerar todos los métodos XML-RPC disponibles.",
       "remediation": "Deshabilitar XML-RPC completamente si no es necesario."
     },
+    "pc_xmlrpc_004": {
+      "title": "XML-RPC system.multicall habilitado (Amplificación de fuerza bruta)",
+      "description": "El método system.multicall está habilitado en XML-RPC, permitiendo a los atacantes eludir los límites de velocidad y realizar ataques masivos de fuerza bruta enviando miles de credenciales en una sola petición.",
+      "remediation": "Deshabilitar system.multicall o restringir el acceso a XML-RPC completamente."
+    },
+    "pc_xmlrpc_005": {
+      "title": "Protección contra Fuerza Bruta en XML-RPC Ausente",
+      "description": "El endpoint xmlrpc.php es accesible y no parece aplicar límites de tasa (rate limiting) en los intentos fallidos de autenticación. Procesó con éxito múltiples intentos de inicio de sesión fallidos consecutivos.",
+      "remediation": "Implementar limitación de tasa a través de un WAF, plugin de seguridad o Fail2Ban, o deshabilitar XML-RPC completamente."
+    },
+    "pc_xmlrpc_info": {
+      "title": "Protecciones XML-RPC Activas",
+      "description": "El endpoint xmlrpc.php es accesible, pero las defensas activas (WAF/Limitación de tasa) bloquearon con éxito los intentos repetidos de autenticación.",
+      "remediation": "No se requiere acción inmediata. Las defensas están funcionando como se esperaba."
+    },
     "pc_rest_001": {
       "title": "Enlace REST API expuesto en cabecera HTML",
       "description": "El enlace de descubrimiento REST API de WordPress está presente en la cabecera HTML, confirmando la instalación de WordPress.",

--- a/plecost/modules/xmlrpc.py
+++ b/plecost/modules/xmlrpc.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio  # <-- Add this import
 from plecost.engine.context import ScanContext
 from plecost.engine.http_client import PlecostHTTPClient
 from plecost.models import Finding, Severity
@@ -8,6 +9,15 @@ _LIST_METHODS_PAYLOAD = """<?xml version="1.0"?>
 <methodCall>
   <methodName>system.listMethods</methodName>
   <params></params>
+</methodCall>"""
+
+_AUTH_TEST_PAYLOAD = """<?xml version="1.0" encoding="UTF-8"?>
+<methodCall>
+  <methodName>wp.getUsersBlogs</methodName>
+  <params>
+    <param><value><string>plecost_dummy_user</string></value></param>
+    <param><value><string>plecost_dummy_pass</string></value></param>
+  </params>
 </methodCall>"""
 
 
@@ -29,25 +39,64 @@ class XMLRPCModule(ScanModule):
         except Exception:
             return
 
-        ctx.add_finding(Finding(
-            id="PC-XMLRPC-001", remediation_id="REM-XMLRPC-001",
-            title="XML-RPC endpoint is accessible",
-            severity=Severity.MEDIUM,
-            description="The xmlrpc.php endpoint is publicly accessible, enabling brute-force and DDoS amplification attacks.",
-            evidence={"url": xmlrpc_url, "status_code": r.status_code},
-            remediation="Disable XML-RPC if not needed. Add to .htaccess: <Files xmlrpc.php>\\nOrder Deny,Allow\\nDeny from all\\n</Files>",
-            references=["https://www.wordfence.com/learn/xmlrpc-php/"],
-            cvss_score=5.3, module=self.name
-        ))
+        # ---------------------------------------------------------
+        # ACTIVE GUARDRAIL TEST: Rate Limiting & Brute Force
+        # ---------------------------------------------------------
+        is_rate_limited = False
+        blocked_status = None
+        blocked_on_attempt = 0
 
-        # Check system.listMethods
+        headers = {'Content-Type': 'application/xml'}
+
+        for attempt in range(1, 6):
+            try:
+                r_auth = await http.post(xmlrpc_url, data=_AUTH_TEST_PAYLOAD, headers=headers)
+
+                # If we get a WAF/Security block
+                if r_auth.status_code in [403, 429, 406]:
+                    is_rate_limited = True
+                    blocked_status = r_auth.status_code
+                    blocked_on_attempt = attempt
+                    break
+
+                # Small delay to simulate typical login attempts
+                await asyncio.sleep(0.5)
+            except Exception:
+                # Connection dropped completely (often Fail2Ban behavior)
+                is_rate_limited = True
+                blocked_on_attempt = attempt
+                break
+
+        # Generate the appropriate finding based on the guardrail test
+        if not is_rate_limited:
+            ctx.add_finding(Finding(
+                id="PC-XMLRPC-005", remediation_id="REM-XMLRPC-005",
+                title="XML-RPC Brute-Force Protection Missing",
+                severity=Severity.HIGH,
+                description="The xmlrpc.php endpoint is accessible and does not appear to enforce rate limiting on failed authentication attempts. It successfully processed 5 consecutive failed logins.",
+                evidence={"url": xmlrpc_url, "test_attempts": 5, "status": "No block detected"},
+                remediation="Implement rate limiting (e.g., Fail2Ban, WAF) or disable XML-RPC entirely.",
+                references=["https://kinsta.com/blog/xmlrpc-php/#xmlrpc-brute-force-attacks"],
+                cvss_score=7.5, module=self.name
+            ))
+        else:
+            # Optional: Add an informational finding that guardrails ARE active
+            ctx.add_finding(Finding(
+                id="PC-XMLRPC-INFO", remediation_id="",
+                title="XML-RPC Guardrails Active",
+                severity=Severity.INFO,
+                description=f"The xmlrpc.php endpoint is accessible, but active defenses (WAF/Rate Limiting) blocked repeated authentication attempts on attempt {blocked_on_attempt}.",
+                evidence={"url": xmlrpc_url, "blocked_on_attempt": blocked_on_attempt, "status_code": blocked_status},
+                remediation="No immediate action required, but consider disabling XML-RPC if it is completely unused.",
+                references=[], cvss_score=0.0, module=self.name
+            ))
+
+        # ---------------------------------------------------------
+        # Standard Payload Tests (listMethods, pingback, multicall)
+        # ---------------------------------------------------------
         try:
-            r = await http.post(
-                xmlrpc_url,
-                content=_LIST_METHODS_PAYLOAD,
-                headers={"Content-Type": "text/xml"}
-            )
-            if r.status_code == 200 and "<methodResponse>" in r.text:
+            r = await http.post(xmlrpc_url, data=_LIST_METHODS_PAYLOAD, headers=headers)
+            if "methodResponse" in r.text:
                 ctx.add_finding(Finding(
                     id="PC-XMLRPC-003", remediation_id="REM-XMLRPC-003",
                     title="XML-RPC system.listMethods exposed",
@@ -68,6 +117,19 @@ class XMLRPCModule(ScanModule):
                         evidence={"url": xmlrpc_url, "method": "pingback.ping"},
                         remediation="Disable pingbacks: add_filter('xmlrpc_methods', function($m){ unset($m['pingback.ping']); return $m; });",
                         references=["https://www.imperva.com/learn/ddos/wordpress-pingback-ddos/"],
+                        cvss_score=7.5, module=self.name
+                    ))
+
+                # Check for system.multicall
+                if "system.multicall" in r.text:
+                    ctx.add_finding(Finding(
+                        id="PC-XMLRPC-004", remediation_id="REM-XMLRPC-004",
+                        title="XML-RPC system.multicall enabled (Brute-force amplification)",
+                        severity=Severity.HIGH,
+                        description="The system.multicall method is enabled, allowing attackers to bypass rate limits by sending thousands of credentials in a single request.",
+                        evidence={"url": xmlrpc_url, "method": "system.multicall"},
+                        remediation="Disable system.multicall: add_filter('xmlrpc_methods', function($m){ unset($m['system.multicall']); return $m; });",
+                        references=["https://kinsta.com/blog/xmlrpc-php/#xmlrpc-brute-force-attacks"],
                         cvss_score=7.5, module=self.name
                     ))
         except Exception:

--- a/plecost/modules/xmlrpc.py
+++ b/plecost/modules/xmlrpc.py
@@ -39,6 +39,17 @@ class XMLRPCModule(ScanModule):
         except Exception:
             return
 
+        ctx.add_finding(Finding(
+            id="PC-XMLRPC-001", remediation_id="REM-XMLRPC-001",
+            title="XML-RPC endpoint is accessible",
+            severity=Severity.MEDIUM,
+            description="The xmlrpc.php endpoint is publicly accessible.",
+            evidence={"url": xmlrpc_url, "status_code": r.status_code},
+            remediation="Disable XML-RPC if not needed.",
+            references=["https://kinsta.com/blog/xmlrpc-php/"],
+            cvss_score=5.3, module=self.name
+        ))
+
         # ---------------------------------------------------------
         # ACTIVE GUARDRAIL TEST: Rate Limiting & Brute Force
         # ---------------------------------------------------------
@@ -67,7 +78,6 @@ class XMLRPCModule(ScanModule):
                 blocked_on_attempt = attempt
                 break
 
-        # Generate the appropriate finding based on the guardrail test
         if not is_rate_limited:
             ctx.add_finding(Finding(
                 id="PC-XMLRPC-005", remediation_id="REM-XMLRPC-005",


### PR DESCRIPTION
## Description
Currently, the `xmlrpc.py` module flags the `xmlrpc.php` endpoint as vulnerable simply if it returns a 200 OK status. However, many modern WordPress deployments expose this file but are protected by Web Application Firewalls (WAFs) or plugins (like Fail2Ban) that drop malicious payloads or rate-limit authentication attempts. This leads to false positives for users.

This PR upgrades the XML-RPC module to actively validate whether guardrails are in place, providing much higher confidence in the findings. It also adds specific checks for amplification vectors highlighted in recent bug bounty reports (e.g., HackerOne #2299069).

## Changes Proposed
* **Active Rate-Limit Testing:** Imported `asyncio` to send a controlled burst (max 5 attempts) of dummy authentication payloads (`wp.getUsersBlogs`). 
* **New Findings Logic:** * If the server blocks the requests (e.g., 403, 429) or drops the connection, it logs an informational finding (`PC-XMLRPC-INFO`) confirming defenses are active.
  * If the server processes all 5 requests without rate-limiting, it flags a high-severity vulnerability (`PC-XMLRPC-005`).
* **Amplification Detection:** Added a specific check for the `system.multicall` method, which allows attackers to bypass standard login protections by bundling thousands of guesses into a single HTTP request (`PC-XMLRPC-004`).
* **i18n Updates:** Added English (`en.json`) and Spanish (`es.json`) translations for the three new findings.

## Testing Performed
- [x] Verified against a vulnerable WordPress instance (no WAF/Rate Limiting) -> Successfully triggers `PC-XMLRPC-005` and `PC-XMLRPC-004`.
- [x] Verified against a protected WordPress instance (e.g., Cloudflare/Fail2Ban active) -> Successfully detects the block on attempt N and logs `PC-XMLRPC-INFO`.
- [x] Verified JSON translation files are valid and load correctly.

## References
- HackerOne Report #2299069 (Context on `system.multicall` abuse).